### PR TITLE
Right justify presentation header

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -56,6 +56,7 @@ body {
   align-items: center;
   gap: 12px;
   min-width: 0;
+  margin-left: auto;
 }
 
 .logo {
@@ -73,7 +74,6 @@ body {
 }
 
 .controls {
-  margin-left: auto;
   display: flex;
   align-items: center;
   gap: 12px;


### PR DESCRIPTION
## Summary
- Move brand section to the right of the header
- Remove auto left margin on controls to support right-justified title

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c1a9589a508328a7d76e8c3b84d90c