### PR TITLE
Align header logo left and title right

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,20 +8,18 @@
 </head>
 <body>
   <div class="container">
-    <header class="header" role="banner">
-      <div class="brand">
+      <header class="header" role="banner">
         <img
           class="logo"
           src="turner-logo.svg"
           alt="Turner logo"
         />
+        <div class="controls">
+          <label class="btn" for="jsonFile" title="Load Presentation">📁 Load Presentation</label>
+          <input id="jsonFile" type="file" accept=".json" style="display:none"/>
+        </div>
         <div class="presentation-title" id="presentationTitle">Presentation Companion</div>
-      </div>
-      <div class="controls">
-        <label class="btn" for="jsonFile" title="Load Presentation">📁 Load Presentation</label>
-        <input id="jsonFile" type="file" accept=".json" style="display:none"/>
-      </div>
-    </header>
+      </header>
 
     <main class="main-content">
       <section class="slide-area" aria-live="polite">

--- a/styles.css
+++ b/styles.css
@@ -51,14 +51,6 @@ body {
   z-index: 10;
 }
 
-.brand {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  min-width: 0;
-  margin-left: auto;
-}
-
 .logo {
   height: 28px;
   display: block;
@@ -71,6 +63,9 @@ body {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  margin-left: auto;
+  text-align: right;
+  min-width: 0;
 }
 
 .controls {


### PR DESCRIPTION
## Summary
- Separate header logo and title elements so the Turner logo sits on the left and the title on the right.
- Simplify header styles, removing unused wrapper and ensuring the title flexes to the far edge.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c1acbe0dc0832881b496e0ee4b2dc1