### PR TITLE
Use tooltips for prompts and attachments labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,11 +35,11 @@
 
       <section class="interactive-section" id="interactiveSection">
         <div class="section-group" id="promptsGroup" style="display:none">
-          <div class="section-label">Prompts (Open in ChatGPT)</div>
+          <div class="section-label" title="Open in ChatGPT">Prompts</div>
           <div class="prompts-container" id="promptsContainer"></div>
         </div>
         <div class="section-group" id="attachmentsGroup" style="display:none">
-          <div class="section-label">Attachments (Click to Open)</div>
+          <div class="section-label" title="Click to open">Attachments</div>
           <div class="attachments-container" id="attachmentsContainer"></div>
         </div>
       </section>

--- a/script.js
+++ b/script.js
@@ -30,11 +30,15 @@ const el = {
   notesToggle: document.getElementById('notesToggle'),
   jsonFile: document.getElementById('jsonFile'),
   loadLabel: document.querySelector('label[for="jsonFile"]'),
-  toast: document.getElementById('toast')
+  toast: document.getElementById('toast'),
+  promptPreview: null
 };
 
 function init() {
   setupEvents();
+  el.promptPreview = document.createElement('div');
+  el.promptPreview.className = 'prompt-preview';
+  document.body.appendChild(el.promptPreview);
   try {
     const saved = localStorage.getItem('presentationData');
     if (saved) {
@@ -117,6 +121,7 @@ function loadPresentation() {
 
 function renderSlide() {
   const slide = presentation.slides[currentSlideIndex];
+  hidePromptPreview();
   el.progressIndicator.textContent = `${currentSlideIndex + 1} / ${presentation.slides.length}`;
 
   let html = "";
@@ -136,9 +141,16 @@ function renderSlide() {
   // Render prompts
   if (slide.prompts?.length) {
     el.promptsContainer.innerHTML = slide.prompts.map((p, i) =>
-      `<a class="chip" href="https://chatgpt.com/?prompt=${encodeURIComponent(p)}" target="_blank" rel="noopener" title="Open in ChatGPT">💬 Prompt ${i + 1}</a>`
+      `<a class="chip" href="https://chatgpt.com/?prompt=${encodeURIComponent(p)}" target="_blank" rel="noopener">💬 Prompt ${i + 1}</a>`
     ).join("");
     el.promptsGroup.style.display = "flex";
+    el.promptsContainer.querySelectorAll('.chip').forEach((ch, i) => {
+      const promptText = slide.prompts[i];
+      ch.addEventListener('mouseenter', () => showPromptPreview(promptText, ch));
+      ch.addEventListener('mouseleave', hidePromptPreview);
+      ch.addEventListener('focus', () => showPromptPreview(promptText, ch));
+      ch.addEventListener('blur', hidePromptPreview);
+    });
   } else {
     el.promptsGroup.style.display = "none";
   }
@@ -189,6 +201,20 @@ function toggleFullscreen() {
     document.documentElement.requestFullscreen();
   } else {
     document.exitFullscreen();
+  }
+}
+
+function showPromptPreview(text, anchor) {
+  el.promptPreview.textContent = text;
+  const rect = anchor.getBoundingClientRect();
+  el.promptPreview.style.display = 'block';
+  el.promptPreview.style.top = `${window.scrollY + rect.bottom + 6}px`;
+  el.promptPreview.style.left = `${window.scrollX + rect.left}px`;
+}
+
+function hidePromptPreview() {
+  if (el.promptPreview) {
+    el.promptPreview.style.display = 'none';
   }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -265,6 +265,21 @@ body {
   border-color: var(--bright-blue);
 }
 
+.prompt-preview {
+  position: absolute;
+  display: none;
+  background: linear-gradient(135deg, #fff8e6, #fff3cc);
+  border: 1px solid #f1c232;
+  padding: 10px;
+  border-radius: 8px;
+  color: #5b4b00;
+  box-shadow: 0 4px 10px var(--shadow);
+  max-width: 300px;
+  z-index: 20;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
 .navigation {
   position: relative;
   display: flex;


### PR DESCRIPTION
## Summary
- Replace verbose prompt and attachment labels with concise text and tooltips
- Show full prompt text in a yellow preview panel when hovering a prompt

## Testing
- `npm test` *(fails: Could not read package.json: ENOENT)*

------
https://chatgpt.com/codex/tasks/task_b_68c1bc91eb5483288b3a12c812dec0db