### PR TITLE
feat: display prompts in centered modal

### DIFF
--- a/script.js
+++ b/script.js
@@ -31,14 +31,20 @@ const el = {
   jsonFile: document.getElementById('jsonFile'),
   loadLabel: document.querySelector('label[for="jsonFile"]'),
   toast: document.getElementById('toast'),
-  promptPreview: null
+  promptPreview: null,
+  promptOverlay: null
 };
 
 function init() {
   setupEvents();
+  el.promptOverlay = document.createElement('div');
+  el.promptOverlay.className = 'prompt-overlay';
   el.promptPreview = document.createElement('div');
   el.promptPreview.className = 'prompt-preview';
-  document.body.appendChild(el.promptPreview);
+  el.promptOverlay.appendChild(el.promptPreview);
+  document.body.appendChild(el.promptOverlay);
+  el.promptOverlay.addEventListener('click', hidePromptPreview);
+  el.promptPreview.addEventListener('click', (e) => e.stopPropagation());
   try {
     const saved = localStorage.getItem('presentationData');
     if (saved) {
@@ -73,6 +79,9 @@ function setupEvents() {
       case 'f':
       case 'F':
         toggleFullscreen();
+        break;
+      case 'Escape':
+        hidePromptPreview();
         break;
     }
   });
@@ -146,10 +155,8 @@ function renderSlide() {
     el.promptsGroup.style.display = "flex";
     el.promptsContainer.querySelectorAll('.chip').forEach((ch, i) => {
       const promptText = slide.prompts[i];
-      ch.addEventListener('mouseenter', () => showPromptPreview(promptText, ch));
-      ch.addEventListener('mouseleave', hidePromptPreview);
-      ch.addEventListener('focus', () => showPromptPreview(promptText, ch));
-      ch.addEventListener('blur', hidePromptPreview);
+      ch.addEventListener('mouseenter', () => showPromptPreview(promptText));
+      ch.addEventListener('focus', () => showPromptPreview(promptText));
     });
   } else {
     el.promptsGroup.style.display = "none";
@@ -204,17 +211,14 @@ function toggleFullscreen() {
   }
 }
 
-function showPromptPreview(text, anchor) {
+function showPromptPreview(text) {
   el.promptPreview.textContent = text;
-  const rect = anchor.getBoundingClientRect();
-  el.promptPreview.style.display = 'block';
-  el.promptPreview.style.top = `${window.scrollY + rect.bottom + 6}px`;
-  el.promptPreview.style.left = `${window.scrollX + rect.left}px`;
+  el.promptOverlay.style.display = 'flex';
 }
 
 function hidePromptPreview() {
-  if (el.promptPreview) {
-    el.promptPreview.style.display = 'none';
+  if (el.promptOverlay) {
+    el.promptOverlay.style.display = 'none';
   }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -265,19 +265,28 @@ body {
   border-color: var(--bright-blue);
 }
 
-.prompt-preview {
-  position: absolute;
+.prompt-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
   display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+}
+
+.prompt-preview {
   background: linear-gradient(135deg, #fff8e6, #fff3cc);
-  border: 1px solid #f1c232;
-  padding: 10px;
+  border: 2px solid #f1c232;
+  padding: 24px;
   border-radius: 8px;
   color: #5b4b00;
-  box-shadow: 0 4px 10px var(--shadow);
-  max-width: 300px;
-  z-index: 20;
-  font-size: 13px;
-  line-height: 1.4;
+  box-shadow: 0 8px 20px var(--shadow);
+  max-width: 80%;
+  max-height: 80%;
+  overflow: auto;
+  font-size: 18px;
+  line-height: 1.6;
 }
 
 .navigation {


### PR DESCRIPTION
## Summary
- display prompt preview in a centered modal overlay for better visibility
- allow closing preview via overlay click or Escape key
- style modal for larger readable text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c1c18c1fb4832888a3a36fab34e6c5