### PR TITLE
Add ChatGPT link in prompt modal

### DIFF
--- a/script.js
+++ b/script.js
@@ -212,7 +212,22 @@ function toggleFullscreen() {
 }
 
 function showPromptPreview(text) {
-  el.promptPreview.textContent = text;
+  const encoded = encodeURIComponent(text);
+  el.promptPreview.innerHTML = '';
+
+  const textDiv = document.createElement('div');
+  textDiv.className = 'prompt-text';
+  textDiv.textContent = text;
+
+  const openLink = document.createElement('a');
+  openLink.className = 'btn prompt-open-btn';
+  openLink.href = `https://chatgpt.com/?prompt=${encoded}`;
+  openLink.target = '_blank';
+  openLink.rel = 'noopener';
+  openLink.textContent = 'Open in ChatGPT';
+
+  el.promptPreview.appendChild(textDiv);
+  el.promptPreview.appendChild(openLink);
   el.promptOverlay.style.display = 'flex';
 }
 

--- a/styles.css
+++ b/styles.css
@@ -287,6 +287,20 @@ body {
   overflow: auto;
   font-size: 18px;
   line-height: 1.6;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.prompt-text {
+  font-family: monospace;
+  white-space: pre-wrap;
+}
+
+.prompt-open-btn {
+  align-self: flex-end;
+  margin-top: 4px;
+  text-decoration: none;
 }
 
 .navigation {


### PR DESCRIPTION
## Summary
- Add ChatGPT launch button inside prompt preview overlay
- Style prompt preview to resemble text prompt with monospace font and action button

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c1c3e0e3fc8328b16f9cb5ad5847bb